### PR TITLE
Alex/add header nav

### DIFF
--- a/src/modules/ui/Header.js
+++ b/src/modules/ui/Header.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { Link } from "gatsby"
 
 import { grantsData } from "@src/utils.js" //TODO: rename this component to specify that it displays grant stats
 
@@ -9,13 +8,23 @@ import {
   IntroHeader,
   IntroHeaderHighlight,
   IntroContent,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavLink,
 } from "./styles/Header.styles"
 
 export default () => (
   <IntroWrapper>
-    <Link to="/" style={{"align-self": 'center', 'text-align': 'center', 'margin': 'auto', 'grid-column': '1 / -1', 'grid-row': '1'}}>
-      <LogoMaker src={"makerlogo.svg"} alt="Logo"></LogoMaker>
-    </Link>
-
+    <HeaderNav>
+      <HeaderNavItem>
+        <HeaderNavLink to="/">Grants</HeaderNavLink>
+      </HeaderNavItem>
+      <HeaderNavItem>
+        <LogoMaker src={"makerlogo.svg"} alt="Logo"></LogoMaker>
+      </HeaderNavItem>
+      <HeaderNavItem>
+        <HeaderNavLink to="/meetups">Meetups</HeaderNavLink>
+      </HeaderNavItem>
+    </HeaderNav>
   </IntroWrapper>
 )

--- a/src/modules/ui/styles/Header.styles.js
+++ b/src/modules/ui/styles/Header.styles.js
@@ -1,5 +1,6 @@
 import styled from "styled-components"
 import { device } from "@src/styles/mediaqueries"
+import { Link } from "gatsby"
 
 export const IntroWrapper = styled.section`
   display: grid;
@@ -20,11 +21,38 @@ export const LogoMaker = styled.img`
   align-self: center;
 `
 
+export const HeaderNav = styled.ul`
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  list-style: none;
+  width: 100%;
+  padding: 0;
+`
+
+export const HeaderNavItem = styled.li`
+  margin: 0rem 1rem;
+`
+
+export const HeaderNavLink = styled(Link)`
+  color: ${props => props.theme.colors.headline_color};
+  border-bottom: 2px solid transparent;
+  transition: 0.2s ease;
+  text-decoration: none;
+  padding-bottom: 0.25rem;
+
+  &:hover {
+    border-bottom: 2px solid ${props => props.theme.colors.headline_color};
+  }
+`
+
 export const IntroHeader = styled.h1`
   grid-column: 1 / -1;
   grid-row: 2;
   color: var(--headline-color);
-  text-align: center; 
+  text-align: center;
 
   @media ${device.mobileL} {
     font-size: 2.25rem;
@@ -43,8 +71,8 @@ export const IntroContent = styled.h2`
   font-weight: 400rem;
   max-width: 720px;
   line-height: 140%;
-  text-align: center; 
-  margin: 1rem auto; 
+  text-align: center;
+  margin: 1rem auto;
 
   @media ${device.mobileL} {
     padding: 1rem 2rem 0rem 2rem;


### PR DESCRIPTION
# Changes

Adds new `HeaderNav`, `HeaderNavItem`, & `HeaderNavLink` components to display `Grants` and `Meetups` links. 

Grants point to the root URL and Meetups to `/meetups`

# Reference
![image](https://user-images.githubusercontent.com/6787950/79160782-bf92b380-7db0-11ea-92cc-9946114b52a2.png)

# To Do
1. - [ ] Set `opacity: 0.7;` on the inactive nav link (e.g. if the current loction === `/` set "Meetups" link to `opacity:0.7;` but if current location === `/meetups` set "Grants" link to `opacity: 0.7`;